### PR TITLE
Fix book/embedonomicon

### DIFF
--- a/route53.tf
+++ b/route53.tf
@@ -86,12 +86,23 @@ resource "aws_route53_record" "rust_embedded_com_www" {
   }
 }
 
+resource "aws_s3_bucket" "book_rust_embedded_com_redirect" {
+  bucket = "book.rust-embedded.com"
+  acl = "public-read"
+  website {
+    redirect_all_requests_to = "book.rust-embedded.org"
+  }
+}
+
 resource "aws_route53_record" "rust_embedded_com_book" {
   zone_id = "${aws_route53_zone.rust_embedded_com.zone_id}"
   name = "book.rust-embedded.com."
-  type = "CNAME"
-  ttl = "300"
-  records = [ "book.rust-embedded.org" ]
+  type = "A"
+  alias {
+    name    = "${aws_s3_bucket.book_rust_embedded_com_redirect.website_domain}"
+    zone_id = "${aws_s3_bucket.book_rust_embedded_com_redirect.hosted_zone_id}"
+    evaluate_target_health = false
+  }
 }
 
 resource "aws_s3_bucket" "embedonomicon_rust_embedded_com_redirect" {

--- a/route53.tf
+++ b/route53.tf
@@ -32,7 +32,7 @@ resource "aws_route53_record" "rust_embedded_org_book" {
   name = "book.rust-embedded.org."
   type = "CNAME"
   ttl = "300"
-  records = [ "rust-embedded.org" ]
+  records = [ "rust-embedded.github.io" ]
 }
 
 resource "aws_route53_record" "rust_embedded_org_embedonomicon" {
@@ -40,7 +40,7 @@ resource "aws_route53_record" "rust_embedded_org_embedonomicon" {
   name = "embedonomicon.rust-embedded.org."
   type = "CNAME"
   ttl = "300"
-  records = [ "rust-embedded.org" ]
+  records = [ "rust-embedded.github.io" ]
 }
 
 // rust-embedded.com


### PR DESCRIPTION
@ryankurte If I am reading the Github pages documentation correctly I believe our current issues with bad certificates are caused by the book/embedonomicon `CNAME`s being pointed to `rust-embedded.org` instead of the `github.io` domain.

Here's the document I'm referring to: https://help.github.com/articles/setting-up-a-custom-subdomain/