### PR TITLE
Replace book, embedonomicon with docs subdomain

### DIFF
--- a/route53.tf
+++ b/route53.tf
@@ -1,4 +1,5 @@
 // rust-embedded.org
+
 resource "aws_route53_zone" "rust_embedded_org" {
   name = "rust-embedded.org."
 }
@@ -27,23 +28,16 @@ resource "aws_route53_record" "rust_embedded_org_www" {
   records = [ "rust-embedded.org" ]
 }
 
-resource "aws_route53_record" "rust_embedded_org_book" {
+resource "aws_route53_record" "rust_embedded_org_docs" {
   zone_id = "${aws_route53_zone.rust_embedded_org.zone_id}"
-  name = "book.rust-embedded.org."
-  type = "CNAME"
-  ttl = "300"
-  records = [ "rust-embedded.org" ]
-}
-
-resource "aws_route53_record" "rust_embedded_org_embedonomicon" {
-  zone_id = "${aws_route53_zone.rust_embedded_org.zone_id}"
-  name = "embedonomicon.rust-embedded.org."
+  name = "docs.rust-embedded.org."
   type = "CNAME"
   ttl = "300"
   records = [ "rust-embedded.org" ]
 }
 
 // rust-embedded.com
+
 resource "aws_route53_zone" "rust_embedded_com" {
   name = "rust-embedded.com."
 }
@@ -82,33 +76,6 @@ resource "aws_route53_record" "rust_embedded_com_www" {
   alias {
     name    = "${aws_s3_bucket.www_rust_embedded_com_redirect.website_domain}"
     zone_id = "${aws_s3_bucket.www_rust_embedded_com_redirect.hosted_zone_id}"
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "rust_embedded_com_book" {
-  zone_id = "${aws_route53_zone.rust_embedded_com.zone_id}"
-  name = "book.rust-embedded.com."
-  type = "CNAME"
-  ttl = "300"
-  records = [ "book.rust-embedded.org" ]
-}
-
-resource "aws_s3_bucket" "embedonomicon_rust_embedded_com_redirect" {
-  bucket = "embedonomicon.rust-embedded.com"
-  acl = "public-read"
-  website {
-    redirect_all_requests_to = "embedonomicon.rust-embedded.org"
-  }
-}
-
-resource "aws_route53_record" "rust_embedded_com_embedonomicon" {
-  zone_id   = "${aws_route53_zone.rust_embedded_com.zone_id}"
-  name      = "embedonomicon.rust-embedded.com."
-  type      = "A"
-  alias {
-    name    = "${aws_s3_bucket.embedonomicon_rust_embedded_com_redirect.website_domain}"
-    zone_id = "${aws_s3_bucket.embedonomicon_rust_embedded_com_redirect.hosted_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/route53.tf
+++ b/route53.tf
@@ -31,9 +31,17 @@ resource "aws_route53_record" "rust_embedded_org_www" {
 resource "aws_route53_record" "rust_embedded_org_docs" {
   zone_id = "${aws_route53_zone.rust_embedded_org.zone_id}"
   name = "docs.rust-embedded.org."
-  type = "CNAME"
+  type = "A"
   ttl = "300"
-  records = [ "rust-embedded.org" ]
+
+  // Github apex domain IP addresses
+  // https://help.github.com/articles/setting-up-an-apex-domain/
+  records = [
+    "185.199.108.153",
+    "185.199.109.153",
+    "185.199.110.153",
+    "185.199.111.153"
+  ]
 }
 
 // rust-embedded.com

--- a/route53.tf
+++ b/route53.tf
@@ -31,17 +31,9 @@ resource "aws_route53_record" "rust_embedded_org_www" {
 resource "aws_route53_record" "rust_embedded_org_docs" {
   zone_id = "${aws_route53_zone.rust_embedded_org.zone_id}"
   name = "docs.rust-embedded.org."
-  type = "A"
+  type = "CNAME"
   ttl = "300"
-
-  // Github apex domain IP addresses
-  // https://help.github.com/articles/setting-up-an-apex-domain/
-  records = [
-    "185.199.108.153",
-    "185.199.109.153",
-    "185.199.110.153",
-    "185.199.111.153"
-  ]
+  records = [ "rust-embedded.github.io" ]
 }
 
 // rust-embedded.com

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.11.10",
-    "serial": 15,
+    "serial": 16,
     "lineage": "06aae676-abab-bb3e-6cf0-33dcc3b68c52",
     "modules": [
         {
@@ -314,21 +314,18 @@
                         "aws_route53_zone.rust_embedded_org"
                     ],
                     "primary": {
-                        "id": "Z1K6QDM5H6MZNC_docs.rust-embedded.org_A",
+                        "id": "Z1K6QDM5H6MZNC_docs.rust-embedded.org_CNAME",
                         "attributes": {
                             "allow_overwrite": "true",
                             "fqdn": "docs.rust-embedded.org",
                             "health_check_id": "",
-                            "id": "Z1K6QDM5H6MZNC_docs.rust-embedded.org_A",
+                            "id": "Z1K6QDM5H6MZNC_docs.rust-embedded.org_CNAME",
                             "name": "docs.rust-embedded.org",
-                            "records.#": "4",
-                            "records.3666638887": "185.199.110.153",
-                            "records.3891024279": "185.199.111.153",
-                            "records.482396659": "185.199.109.153",
-                            "records.564191299": "185.199.108.153",
+                            "records.#": "1",
+                            "records.4247522484": "rust-embedded.github.io",
                             "set_identifier": "",
                             "ttl": "300",
-                            "type": "A",
+                            "type": "CNAME",
                             "zone_id": "Z1K6QDM5H6MZNC"
                         },
                         "meta": {

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.11.10",
-    "serial": 13,
+    "serial": 14,
     "lineage": "06aae676-abab-bb3e-6cf0-33dcc3b68c52",
     "modules": [
         {
@@ -245,66 +245,6 @@
                     "deposed": [],
                     "provider": "provider.aws"
                 },
-                "aws_route53_record.rust_embedded_com_book": {
-                    "type": "aws_route53_record",
-                    "depends_on": [
-                        "aws_route53_zone.rust_embedded_com"
-                    ],
-                    "primary": {
-                        "id": "Z2GJVQBHJNLGYL_book.rust-embedded.com._CNAME",
-                        "attributes": {
-                            "allow_overwrite": "true",
-                            "fqdn": "book.rust-embedded.com",
-                            "health_check_id": "",
-                            "id": "Z2GJVQBHJNLGYL_book.rust-embedded.com._CNAME",
-                            "name": "book.rust-embedded.com",
-                            "records.#": "1",
-                            "records.36008064": "book.rust-embedded.org",
-                            "set_identifier": "",
-                            "ttl": "300",
-                            "type": "CNAME",
-                            "zone_id": "Z2GJVQBHJNLGYL"
-                        },
-                        "meta": {
-                            "schema_version": "2"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.aws"
-                },
-                "aws_route53_record.rust_embedded_com_embedonomicon": {
-                    "type": "aws_route53_record",
-                    "depends_on": [
-                        "aws_route53_zone.rust_embedded_com",
-                        "aws_s3_bucket.embedonomicon_rust_embedded_com_redirect"
-                    ],
-                    "primary": {
-                        "id": "Z2GJVQBHJNLGYL_embedonomicon.rust-embedded.com_A",
-                        "attributes": {
-                            "alias.#": "1",
-                            "alias.2781413164.evaluate_target_health": "false",
-                            "alias.2781413164.name": "s3-website-us-east-1.amazonaws.com",
-                            "alias.2781413164.zone_id": "Z3AQBSTGFYJSTF",
-                            "allow_overwrite": "true",
-                            "fqdn": "embedonomicon.rust-embedded.com",
-                            "health_check_id": "",
-                            "id": "Z2GJVQBHJNLGYL_embedonomicon.rust-embedded.com_A",
-                            "name": "embedonomicon.rust-embedded.com",
-                            "records.#": "0",
-                            "set_identifier": "",
-                            "ttl": "0",
-                            "type": "A",
-                            "zone_id": "Z2GJVQBHJNLGYL"
-                        },
-                        "meta": {
-                            "schema_version": "2"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.aws"
-                },
                 "aws_route53_record.rust_embedded_com_www": {
                     "type": "aws_route53_record",
                     "depends_on": [
@@ -368,50 +308,20 @@
                     "deposed": [],
                     "provider": "provider.aws"
                 },
-                "aws_route53_record.rust_embedded_org_book": {
+                "aws_route53_record.rust_embedded_org_docs": {
                     "type": "aws_route53_record",
                     "depends_on": [
                         "aws_route53_zone.rust_embedded_org"
                     ],
                     "primary": {
-                        "id": "Z1K6QDM5H6MZNC_book.rust-embedded.org._CNAME",
+                        "id": "Z1K6QDM5H6MZNC_docs.rust-embedded.org._CNAME",
                         "attributes": {
                             "allow_overwrite": "true",
-                            "fqdn": "book.rust-embedded.org",
-                            "health_check_id": "",
-                            "id": "Z1K6QDM5H6MZNC_book.rust-embedded.org._CNAME",
-                            "name": "book.rust-embedded.org",
+                            "fqdn": "docs.rust-embedded.org",
+                            "id": "Z1K6QDM5H6MZNC_docs.rust-embedded.org._CNAME",
+                            "name": "docs.rust-embedded.org",
                             "records.#": "1",
                             "records.4141188299": "rust-embedded.org",
-                            "set_identifier": "",
-                            "ttl": "300",
-                            "type": "CNAME",
-                            "zone_id": "Z1K6QDM5H6MZNC"
-                        },
-                        "meta": {
-                            "schema_version": "2"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.aws"
-                },
-                "aws_route53_record.rust_embedded_org_embedonomicon": {
-                    "type": "aws_route53_record",
-                    "depends_on": [
-                        "aws_route53_zone.rust_embedded_org"
-                    ],
-                    "primary": {
-                        "id": "Z1K6QDM5H6MZNC_embedonomicon.rust-embedded.org._CNAME",
-                        "attributes": {
-                            "allow_overwrite": "true",
-                            "fqdn": "embedonomicon.rust-embedded.org",
-                            "health_check_id": "",
-                            "id": "Z1K6QDM5H6MZNC_embedonomicon.rust-embedded.org._CNAME",
-                            "name": "embedonomicon.rust-embedded.org",
-                            "records.#": "1",
-                            "records.4141188299": "rust-embedded.org",
-                            "set_identifier": "",
                             "ttl": "300",
                             "type": "CNAME",
                             "zone_id": "Z1K6QDM5H6MZNC"
@@ -556,45 +466,6 @@
                             "website.0.routing_rules": "",
                             "website_domain": "s3-website-us-east-1.amazonaws.com",
                             "website_endpoint": "areweembeddedyet.com.s3-website-us-east-1.amazonaws.com"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.aws"
-                },
-                "aws_s3_bucket.embedonomicon_rust_embedded_com_redirect": {
-                    "type": "aws_s3_bucket",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "embedonomicon.rust-embedded.com",
-                        "attributes": {
-                            "acceleration_status": "",
-                            "acl": "public-read",
-                            "arn": "arn:aws:s3:::embedonomicon.rust-embedded.com",
-                            "bucket": "embedonomicon.rust-embedded.com",
-                            "bucket_domain_name": "embedonomicon.rust-embedded.com.s3.amazonaws.com",
-                            "bucket_regional_domain_name": "embedonomicon.rust-embedded.com.s3.amazonaws.com",
-                            "cors_rule.#": "0",
-                            "force_destroy": "false",
-                            "hosted_zone_id": "Z3AQBSTGFYJSTF",
-                            "id": "embedonomicon.rust-embedded.com",
-                            "logging.#": "0",
-                            "region": "us-east-1",
-                            "replication_configuration.#": "0",
-                            "request_payer": "BucketOwner",
-                            "server_side_encryption_configuration.#": "0",
-                            "tags.%": "0",
-                            "versioning.#": "1",
-                            "versioning.0.enabled": "false",
-                            "versioning.0.mfa_delete": "false",
-                            "website.#": "1",
-                            "website.0.error_document": "",
-                            "website.0.index_document": "",
-                            "website.0.redirect_all_requests_to": "embedonomicon.rust-embedded.org",
-                            "website.0.routing_rules": "",
-                            "website_domain": "s3-website-us-east-1.amazonaws.com",
-                            "website_endpoint": "embedonomicon.rust-embedded.com.s3-website-us-east-1.amazonaws.com"
                         },
                         "meta": {},
                         "tainted": false

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.11.10",
-    "serial": 14,
+    "serial": 15,
     "lineage": "06aae676-abab-bb3e-6cf0-33dcc3b68c52",
     "modules": [
         {
@@ -314,16 +314,21 @@
                         "aws_route53_zone.rust_embedded_org"
                     ],
                     "primary": {
-                        "id": "Z1K6QDM5H6MZNC_docs.rust-embedded.org._CNAME",
+                        "id": "Z1K6QDM5H6MZNC_docs.rust-embedded.org_A",
                         "attributes": {
                             "allow_overwrite": "true",
                             "fqdn": "docs.rust-embedded.org",
-                            "id": "Z1K6QDM5H6MZNC_docs.rust-embedded.org._CNAME",
+                            "health_check_id": "",
+                            "id": "Z1K6QDM5H6MZNC_docs.rust-embedded.org_A",
                             "name": "docs.rust-embedded.org",
-                            "records.#": "1",
-                            "records.4141188299": "rust-embedded.org",
+                            "records.#": "4",
+                            "records.3666638887": "185.199.110.153",
+                            "records.3891024279": "185.199.111.153",
+                            "records.482396659": "185.199.109.153",
+                            "records.564191299": "185.199.108.153",
+                            "set_identifier": "",
                             "ttl": "300",
-                            "type": "CNAME",
+                            "type": "A",
                             "zone_id": "Z1K6QDM5H6MZNC"
                         },
                         "meta": {


### PR DESCRIPTION
Implements changes requested in https://github.com/rust-embedded/wg/issues/208

Output of terraform plan:
```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  - destroy

Terraform will perform the following actions:

  - aws_route53_record.rust_embedded_com_book

  - aws_route53_record.rust_embedded_com_embedonomicon

  - aws_route53_record.rust_embedded_org_book

  + aws_route53_record.rust_embedded_org_docs
      id:                 <computed>
      allow_overwrite:    "true"
      fqdn:               <computed>
      name:               "docs.rust-embedded.org"
      records.#:          "1"
      records.4141188299: "rust-embedded.org"
      ttl:                "300"
      type:               "CNAME"
      zone_id:            "Z1K6QDM5H6MZNC"

  - aws_route53_record.rust_embedded_org_embedonomicon

  - aws_s3_bucket.embedonomicon_rust_embedded_com_redirect


Plan: 1 to add, 0 to change, 5 to destroy.

------------------------------------------------------------------------
```